### PR TITLE
Don't require elm-lang/html

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,7 +11,6 @@
     ],
     "dependencies": {
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "krisajenkins/remotedata": "4.3.0 <= v < 5.0.0"
     },


### PR DESCRIPTION
First, thanks for the package, and for your talk at elm-conf; I just watched it and it's helped me feel more prepared.

Moving on, I could be wrong, and I know almost everyone will be installing it anyway, but I don't think this line in `elm-package.json` is necessary?