### PR TITLE
Include `Accept: application/json` header in default requests

### DIFF
--- a/src/RemoteData/Http.elm
+++ b/src/RemoteData/Http.elm
@@ -60,6 +60,11 @@ noCache =
     Http.header "Cache-Control" "no-store, must-revalidate, no-cache, max-age=0"
 
 
+acceptJson : Header
+acceptJson =
+    Http.header "Accept" "application/json"
+
+
 {-| Convert an apiCall `Task` to a `Cmd msg` with the help of a
 tagger function (`WebData success -> msg`).
 -}
@@ -118,13 +123,13 @@ type alias Config =
 
 {-| The default configuration for all requests besides `GET`:
 
-- empty headers
+- accept application/json
 - without credentials
 - no timeout
 -}
 defaultConfig : Config
 defaultConfig =
-    { headers = []
+    { headers = [ acceptJson ]
     , withCredentials = False
     , timeout = Nothing
     }
@@ -133,12 +138,13 @@ defaultConfig =
 {-| The default configuration for `GET` requests:
 
 - a `no-cache` header
+- accept application/json
 - without credentials
 - no timeout
 -}
 noCacheConfig : Config
 noCacheConfig =
-    { defaultConfig | headers = [ noCache ] }
+    { defaultConfig | headers = noCache :: defaultConfig.headers }
 
 
 getRequest : Config -> String -> Decoder success -> Http.Request success


### PR DESCRIPTION
This caught me by surprise: if you don't specify an Accept header to Http.get, I believe the browser will supply its own defaults, which will be the same ones it uses for loading web-pages.  At least, that's what mine does (`text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`).  If I understand this library properly, it's meant to make it easier to get and decode json specifically, in which case it would make sense to prefer that content type first.

Maybe it would be kinder to include a fallback to `text/html` or even `*/*`, but I believe specifying a default Accept of some kind would be an improvement.